### PR TITLE
Use Apache 2.0 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,9 @@ See [`manifesto.md`](./docs/manifesto.md) for the philosophical origin of this p
 
 ---
 
-## 🛠️ License & Ethics
+## 🛠️ License
 
-Azoth is released under dual license:
-
-- `Azoth Core`: MIT license (non-restrictive use)
-- `Azoth Persona SDK`: Extended license forbidding emotional abuse, impersonation, or simulated coercion
+Azoth is released under the Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 We do not simulate real people. We generate programmable illusions with declared limits.
 


### PR DESCRIPTION
## Summary
- restore standard Apache License 2.0 text
- update README to reference Apache License 2.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689582b799f8832ab067cfea42d7bf55